### PR TITLE
fix moving cursor bug

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -238,13 +238,14 @@ void cw_system_cpu_cycle(void)
                     {
                         chip8.register_v[0xF] = false;
                         uint8_t overflow = false;
+                        uint8_t result = chip8.register_v[INSTR_POS_X] - chip8.register_v[INSTR_POS_Y];
 
-                        if (chip8.register_v[INSTR_POS_X] >= chip8.register_v[INSTR_POS_Y]) {
+                        if (chip8.register_v[INSTR_POS_X] > chip8.register_v[INSTR_POS_Y]) {
                             overflow = true;
                         } else {
                             overflow = false;
                         }
-		    	        chip8.register_v[INSTR_POS_X] = chip8.register_v[INSTR_POS_X] - chip8.register_v[INSTR_POS_Y];
+		    	        chip8.register_v[INSTR_POS_X] = result;
 			            chip8.register_v[0xF] = overflow;
                         chip8.register_program_counter += 2;
                     }
@@ -265,13 +266,14 @@ void cw_system_cpu_cycle(void)
                     {
                         chip8.register_v[0xF] = false;
                         uint8_t overflow = false;
+                        uint8_t result = chip8.register_v[INSTR_POS_Y] - chip8.register_v[INSTR_POS_X];
 
-                        if (chip8.register_v[INSTR_POS_Y] >= chip8.register_v[INSTR_POS_X]) {
+                        if (chip8.register_v[INSTR_POS_X] > chip8.register_v[INSTR_POS_Y]) {
                             overflow = true;
                         } else {
                             overflow = false;
                         }
-			            chip8.register_v[INSTR_POS_X] = chip8.register_v[INSTR_POS_Y] - chip8.register_v[INSTR_POS_X];
+			            chip8.register_v[INSTR_POS_X] = result;
 			            chip8.register_v[0xF] = overflow;
                         chip8.register_program_counter += 2;
                     }

--- a/src/system.c
+++ b/src/system.c
@@ -236,14 +236,13 @@ void cw_system_cpu_cycle(void)
                 // Set register Vx = Vx - Vy, Set register Vf = NOT borrow
                 case 0x5:
                     {
-                        chip8.register_v[0xF] = false;
                         uint8_t overflow = false;
                         uint8_t result = chip8.register_v[INSTR_POS_X] - chip8.register_v[INSTR_POS_Y];
 
-                        if (chip8.register_v[INSTR_POS_X] > chip8.register_v[INSTR_POS_Y]) {
-                            overflow = true;
-                        } else {
+                        if (chip8.register_v[INSTR_POS_Y] > chip8.register_v[INSTR_POS_X]) {
                             overflow = false;
+                        } else {
+                            overflow = true;
                         }
 		    	        chip8.register_v[INSTR_POS_X] = result;
 			            chip8.register_v[0xF] = overflow;
@@ -264,14 +263,13 @@ void cw_system_cpu_cycle(void)
                 // Set register Vx = Vy - Vx, Set register Vf = NOT borrow
                 case 0x7:
                     {
-                        chip8.register_v[0xF] = false;
                         uint8_t overflow = false;
                         uint8_t result = chip8.register_v[INSTR_POS_Y] - chip8.register_v[INSTR_POS_X];
 
                         if (chip8.register_v[INSTR_POS_X] > chip8.register_v[INSTR_POS_Y]) {
-                            overflow = true;
-                        } else {
                             overflow = false;
+                        } else {
+                            overflow = true;
                         }
 			            chip8.register_v[INSTR_POS_X] = result;
 			            chip8.register_v[0xF] = overflow;


### PR DESCRIPTION
This is my pr to fix the moving cursor bug. It fixed the moving cursor bug, but the cursor is exceeding the program's screen :(. I didn't quite get why you said I needed v[0] to subtract from the value of vF. The technical ref said the vx and vy are only needed. I just use the result variable for the result of vx and vy. Then check if the subtrahend is bigger than the minimum, then vf is set to 1. Otherwise, leave it at 0. sorry for my english